### PR TITLE
BS-2617 remove scope provided to always include jasperreport lib in the ...

### DIFF
--- a/bonita-connector-jasper-impl/pom.xml
+++ b/bonita-connector-jasper-impl/pom.xml
@@ -30,7 +30,6 @@
                     <artifactId>jdtcore</artifactId>
                 </exclusion>
             </exclusions>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
BS-2617 remove scope provided to always include jasperreport lib in the connector
related successful build: 
http://pollux2.rd.lan/job/connectors/job/all_single-connector-build/3/console
