### PR TITLE
fix(BS-11280) Jasper Connector is not working by default on JBoss

### DIFF
--- a/bonita-connector-jasper-impl/pom.xml
+++ b/bonita-connector-jasper-impl/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>bonita-connector-jasper-impl</artifactId>
-	<version>1.0.4</version>
+	<version>1.0.5</version>
 
 	<properties>
 		<definition.version>1.0.0</definition.version>
@@ -31,7 +31,6 @@
 					<artifactId>jdtcore</artifactId>
 				</exclusion>
 			</exclusions>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
- remove the provided scope from jasper reports dependency
- upgrade connector version

Covers [BS-11280](https://bonitasoft.atlassian.net/browse/BS-11280)
