### PR TITLE
fix(java8): update jdtcore to make connector work on java8

### DIFF
--- a/bonita-connector-jasper-impl/pom.xml
+++ b/bonita-connector-jasper-impl/pom.xml
@@ -32,6 +32,12 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<!-- Needed to work on Java 8, shipped version 3.1.0 does not work with java 8  -->
+		<dependency>
+			<groupId>org.eclipse.jdt</groupId>
+			<artifactId>org.eclipse.jdt.core</artifactId>
+			<version>3.13.50</version>
+		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>


### PR DESCRIPTION
see https://community.jaspersoft.com/jasperreports-library/issues/3498-0

jdtcore must be updated to work with java8, otherwise there is
compilation issues when compiling the report.

Closes [BS-17678](https://bonitasoft.atlassian.net/browse/BS-17678)